### PR TITLE
CASMPET-4419: Fix Keycloak missing PROXY_ADDRESS_FORWARDING env

### DIFF
--- a/kubernetes/cray-keycloak/values.yaml
+++ b/kubernetes/cray-keycloak/values.yaml
@@ -89,6 +89,8 @@ keycloak:
     extraEnv: |
       - name: JAVA_OPTS
         value: -XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0 -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true
+      - name: PROXY_ADDRESS_FORWARDING
+        value: "true"
     basepath: keycloak
     username: admin
     existingSecret: keycloak-master-admin-auth


### PR DESCRIPTION
### Summary and Scope

CASMPET-4394 overrode the extraEnv to set JVM memory options. This
caused the PROXY_ADDRESS_FORWARDING env var to be lost which
caused other problems.

This fix adds the PROXY_ADDRESS_FORWARDING env var back.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES? N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-4419
* Change will also be needed in 1.0

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run? N, doesn't work on vshasta.
Was a fresh Install tested? N   If not, Why? Upgrade/downgrade test should be adequate.
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER)

Manual.

HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Checked that the env var is now defined on the statefulset, keycloak started and I was able to get to a web app (kiali).

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N/A
ARE THERE KNOWN ISSUES WITH THESE CHANGES? No
ANY OTHER SPECIAL CONSIDERATIONS? None.

Requires: None
