### PR TITLE
CASMPET-4644: keycloak-users-localize exits on unrecoverable failure

### DIFF
--- a/kubernetes/cray-keycloak-users-localize/templates/keycloak-users-localize.yaml
+++ b/kubernetes/cray-keycloak-users-localize/templates/keycloak-users-localize.yaml
@@ -1,5 +1,23 @@
 {{- /*
-Copyright 2020 Hewlett Packard Enterprise Development LP
+
+MIT License
+(C) Copyright [2020-2021] Hewlett Packard Enterprise Development LP
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
 */ -}}
 
 ---
@@ -40,10 +58,11 @@ metadata:
   labels:
     {{- include "cray-keycloak-users-localize.labels" . | nindent 4 }}
 spec:
+  backoffLimit: {{ .Values.backoffLimit }}
   template:
     spec:
       serviceAccountName: keycloak-users-localize
-      restartPolicy: OnFailure
+      restartPolicy: Never
       containers:
       - name: keycloak-localize
         image: {{ .Values.image.repository }}:{{ .Values.image.tag | default (include "cray-keycloak-users-localize.app-version" . ) }}

--- a/kubernetes/cray-keycloak-users-localize/values.yaml
+++ b/kubernetes/cray-keycloak-users-localize/values.yaml
@@ -1,8 +1,30 @@
 
+# MIT License
+# (C) Copyright [2020-2021] Hewlett Packard Enterprise Development LP
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
 image:
   repository: dtr.dev.cray.com/cray/cray-keycloak-setup
   # tag: latest
   pullPolicy: Always
+
+# Determines how many times the Job will retry running the localize pod.
+# If it takes longer for things to be ready this can be increased.
+backoffLimit: 3
 
 # Contains the creds for connecting to keycloak as the master administrator.
 keycloakMasterAdminSecretName: keycloak-master-admin-auth


### PR DESCRIPTION
### Summary and Scope

There have been a few cases where keycloak-users-localize gets stuck in
a loop where it's reporting that a group doesn't exist. This is usually
caused by what appears to be the LDAP synchronization either not
happening or only partially finishing. We're often not able to look at
what the original problem was because the Job has been restarted during
the install and the old pods are gone, or the old Job has been looping
so long that the logs have rolled over.

The proposed fix is to have keycloak-users-localize fail and exit
rather than loop in these cases where we've seen the system not
recover. This also requires changing the Job/Pod to not restart the
container when it exits with a failure because otherwise K8s just
restarts the container forever. Also it should be necessary to re-try
the Pod 6 times so the backoffLimit now defaults to 3 attempts.

During my testing I saw that when the Pod fails the first time it
creates the LDAP integration and then the next time it runs the LDAP
integration is already there so the next time it works. Since we want
the Job to show that it failed I added code to clean up the integration
so that it will get recreated the next time and either fail the same
way (or succeed if the problem fixed itself somehow).

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? Bug fix

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

LIST AND CHARACTERIZE RELATIONSHIP TO JIRA ISSUES AND OTHER PULL REQUESTS. BE SURE LIST DEPENDENCIES.

* Resolves CASMPET-4644

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) No, doesn't run on vshasta.
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Tried running with a configuration where the group for the role assignment doesn't exist. The job failed as expected.
Tried running with a configuration where the user for the role assignment doesn't exist. The job failed as expected.
Tried running with an LDAP configuration with a bad Bind DN, the job failed as expected.
Also tried with a correct LDAP and role assignment configuration and the job continued to complete successfully as expected.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? No.
ARE THERE KNOWN ISSUES WITH THESE CHANGES? No.
ANY OTHER SPECIAL CONSIDERATIONS? None.

Requires: None
