### PR TITLE
CASMPET-4692: Change default user to host's nobody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,6 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+USER 65534:65534
+
 CMD [ "python", "keycloak_setup/keycloak_setup.py" ]


### PR DESCRIPTION
### Summary and Scope

On our systems the nobody user on the host is

```
nobody:x:65534:65534:nobody:/var/lib/nobody:/bin/bash
```

This sets the USER for the keycloak-setup image to this same UID
and GID, rather than using the default which is the root user.
The goal is to improve security of the system.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? New feature

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-4692

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc)
Was a fresh Install tested? Y
Was an Upgrade tested?      N   Image change only
Was a Downgrade tested?     N, Image change only
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed cray-keycloak and cray-keycloak-users-localize with this image and made sure they both ran.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? No
ANY OTHER SPECIAL CONSIDERATIONS? No

Requires: None
