### PR TITLE
CASMPET-4835: Run wait-for-postgres as nobody

### DIFF
--- a/kubernetes/cray-keycloak/templates/postgresql.yaml
+++ b/kubernetes/cray-keycloak/templates/postgresql.yaml
@@ -123,6 +123,10 @@ spec:
       containers:
         - name: "postgres-watcher-service-db"
           image: "{{ .Values.imagesHost }}/cache/postgres:13.2"
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true
           command: ["sh", "-c", "until psql postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB -c 'select version();'; do echo waiting for postgres db $POSTGRES_DB; sleep 2; done;  echo 'POSTGRES_READY';"]
           env:
           - name: POSTGRES_USER


### PR DESCRIPTION
### Summary and Scope

Set the securityContext on the keycloak-wait-for-postgres Job so
that the container doesn't get flagged as a violation by
OPA Gatekeeper.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? New feature

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-4835

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) No
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Made sure the Job ran as expected. Checked the Job to make sure it was running with the securityContext as expected.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? None

Requires: None
