### PR TITLE
CASMPET-4866: Set securityContext for setup & localize Jobs

### DIFF
--- a/kubernetes/cray-keycloak-users-localize/templates/keycloak-users-localize.yaml
+++ b/kubernetes/cray-keycloak-users-localize/templates/keycloak-users-localize.yaml
@@ -67,6 +67,10 @@ spec:
       - name: keycloak-localize
         image: {{ .Values.image.repository }}:{{ .Values.image.tag | default (include "cray-keycloak-users-localize.app-version" . ) }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          runAsUser: 65534
+          runAsGroup: 65534
+          runAsNonRoot: true
         env:
         - name: KEYCLOAK_BASE
           value: {{ .Values.keycloakBase }}

--- a/kubernetes/cray-keycloak/templates/keycloak-setup.yaml
+++ b/kubernetes/cray-keycloak/templates/keycloak-setup.yaml
@@ -44,6 +44,10 @@ spec:
       - name: keycloak-setup
         image: {{ .Values.setup.image.repository }}:{{ .Values.setup.image.tag | default (include "cray-keycloak.app-version" . ) }}
         imagePullPolicy: {{ .Values.setup.image.pullPolicy }}
+        securityContext:
+          runAsUser: 65534
+          runAsGroup: 65534
+          runAsNonRoot: true
         env:
         - name: KEYCLOAK_BASE
           value: "http://{{ .Values.setup.keycloak.service }}:8080/keycloak"


### PR DESCRIPTION
### Summary and Scope

The keycloak-setup and keycloak-users-localize Jobs were not
setting the runAsUser for their main containers. This is flagged
by the current OPA Gatekeeper constraint as invalid since
runAsUser needs to be set to something other than 0.

This change sets the runAsUser for the main containers for
keycloak-setup and keycloak-users-localize.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? New Feature?

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES? N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-4866

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER)  MANUAL
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed the updated chart and made sure that the Jobs ran and that they had the updated securityContext.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? None

Requires: None
