### PR TITLE
CASMPET-4714: Create OAuth2-Proxy Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- keycloak_setup: Now creates an `oauth2-proxy` Client and associated Secret
+  with the client secret for use by OAuth2-Proxy.
 
 ## [0.12.6]
 - keycloak_setup: Initial release for CSM 1.0

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ services by requiring valid redirect URIs to be explicitly defined. Also,
 the keycloak-gatekeeper-client secret is created to enable keycloak-gatekeeper
 to connect to Keycloak.
 
+A Client called `oauth2-proxy` is created in Keycloak. This client is used by
+the OAuth2-Proxy ingress to facilitate authentication for web UIs,
+before forwarding traffic to the Istio ingress gateway, which uses OPA and
+enforces authorization. This client is configured to support specific
+services by requiring valid redirect URIs to be explicitly defined. Also,
+the oauth2-proxy-client secret is created that contains the client secret so
+that the OAuth2-Proxy can get the secret.
+
 A Client called `shasta` is created in Keycloak. This client is public and is
 meant to be used when accessing the Cray services. This client has protocol
 mappers that make the uid and gid attributes for the user available to the
@@ -123,10 +131,20 @@ unable to verify the id token	{"error": "oidc: JWT claims invalid: invalid claim
 - KEYCLOAK_GATEKEEPER_PROXIED_HOSTS: JSON-encoded list of hostnames that the
   keycloak-gatekeeper ingress will proxy. Used to set the list of valid
   redirect URIs for the gatekeeper client.
+- KEYCLOAK_OAUTH2_PROXY_CLIENT_ID: Name of the OAuth2-Proxy client.
+  Defaults to `oauth2-proxy`.
+- KEYCLOAK_OAUTH2_PROXY_CLIENT_SECRET_NAME: Name of the secret that stores the
+  OAuth2-Proxy client info. Defaults to `oauth2-proxy-client`.
+- KEYCLOAK_OAUTH2_PROXY_CLIENT_SECRET_NAMESPACES: JSON-encoded list of
+  namespaces that the gatekeeper client secret will be created in. Defaults to
+  `['services']`.
+- KEYCLOAK_OAUTH2_PROXY_CLIENT_PROXIED_HOSTS: JSON-encoded list of hostnames
+  that the OAuth2-Proxy ingress will proxy. Used to set the list of valid
+  redirect URIs for the gatekeeper client.
 - KEYCLOAK_CUSTOMER_ACCESS_URL: The URL used to access Keycloak from the
   customer access network (CAN). Necessary to properly configure
-  keycloak-gatekeeper ingress to connect to Keycloak and redirect users to
-  Keycloak for login.
+  keycloak-gatekeeper/OAuth2-Proxy ingress to connect to Keycloak and redirect
+  users to Keycloak for login.
 - KEYCLOAK_WLM_CLIENT_ID: Name of the WLM client.
   Defaults to `wlm-client`.
 - KEYCLOAK_WLM_CLIENT_SECRET_NAME: Name of the secret that stores the

--- a/kubernetes/cray-keycloak/templates/keycloak-setup.yaml
+++ b/kubernetes/cray-keycloak/templates/keycloak-setup.yaml
@@ -104,6 +104,19 @@ spec:
         - name: KEYCLOAK_GATEKEEPER_CLIENT_SECRET_NAMESPACES
           value: |
             {{ .Values.setup.keycloak.gatekeeper.client.secret.namespaces | toJson }}
+
+        # OAuth2-Proxy client
+        - name: KEYCLOAK_OAUTH2_PROXY_CLIENT_ID
+          value: "{{ .Values.setup.keycloak.oauth2Proxy.client.id }}"
+        - name: KEYCLOAK_OAUTH2_PROXY_CLIENT_SECRET_NAME
+          value: "{{ .Values.setup.keycloak.oauth2Proxy.client.secret.name }}"
+        - name: KEYCLOAK_OAUTH2_PROXY_CLIENT_SECRET_NAMESPACES
+          value: |
+            {{ .Values.setup.keycloak.oauth2Proxy.client.secret.namespaces | toJson }}
+        - name: KEYCLOAK_OAUTH2_PROXY_CLIENT_PROXIED_HOSTS
+          value: |
+            {{ .Values.setup.keycloak.oauth2Proxy.proxiedHosts | toJson }}
+
         # WLM client
         - name: KEYCLOAK_WLM_CLIENT_ID
           value: "{{ .Values.setup.keycloak.wlmClient.id }}"

--- a/kubernetes/cray-keycloak/values.yaml
+++ b/kubernetes/cray-keycloak/values.yaml
@@ -76,6 +76,28 @@ setup:
         - vcs_hostname.local
         - sma-grafana.local
         - sma-kibana.local
+    oauth2Proxy:
+      client:
+        id: oauth2-proxy
+        secret:
+          name: oauth2-proxy-client
+          namespaces:
+            - services
+      proxiedHosts:
+        - shs_prometheus.local
+        - shs_alertmanager.local
+        - shs_grafana.local
+        - istio_prometheus.local
+        - istio_grafana.local
+        - istio_kiali.local
+        - istio_jaeger.local
+        - kube_monitoring_prometheus.local
+        - kube_monitoring_alertmanager.local
+        - kube_monitoring_grafana.local
+        - ceph_monitoring_prometheus.local
+        - vcs_hostname.local
+        - sma-grafana.local
+        - sma-kibana.local
     customerAccessUrl: "https://auth.local/keycloak"
     masterAdminSecretName: keycloak-master-admin-auth
 

--- a/tests/test_keycloak_setup.py
+++ b/tests/test_keycloak_setup.py
@@ -1008,6 +1008,9 @@ class TestKeycloakSetup(testtools.TestCase):
         self.assertEqual(exp, ret)
 
     def test_main(self):
+        self.useFixture(fixtures.EnvironmentVariable(
+            'KEYCLOAK_OAUTH2_PROXY_CLIENT_PROXIED_HOSTS', '[]'))
+
         self.useFixture(fixtures.MockPatchObject(
             keycloak_setup.kubernetes.config, 'load_incluster_config'))
         rkmas_ret = {


### PR DESCRIPTION
### Summary and Scope

The keycloak-setup tool is enhanced to create a new Client for use
with OAuth2-Proxy. It's very similar to the keycloak-gatekeeper
client that keycloak-setup is already creating.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? New feature

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? Y

### Issues and Related PRs

* Resolves CASMPET-4714

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?     N.  If not, Why? keycloak-setup doesn't delete clients/secrets.
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) 
Manual.

HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed this change, made sure the oath2-proxy Client was created in Keycloak and that the oauth2-proxy-client Secret was created after it finished.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? No
ANY OTHER SPECIAL CONSIDERATIONS? No

Requires: None
