### PR TITLE
CASMPET-4953 master : BI-CAN: Update keycloak to use the new API Gate…

### DIFF
--- a/kubernetes/cray-keycloak/templates/ingress.yaml
+++ b/kubernetes/cray-keycloak/templates/ingress.yaml
@@ -13,8 +13,10 @@ metadata:
 spec:
   hosts:
     - "*"
+  {{- with .Values.keycloak.ingress.gateways }}
   gateways:
-    - services-gateway
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   http:
     # This route rule sets the Cache-Control response header when fetching
     # certs so that clients (e.g., OPA) will cache it.

--- a/kubernetes/cray-keycloak/values.yaml
+++ b/kubernetes/cray-keycloak/values.yaml
@@ -106,6 +106,13 @@ keycloak:
   imagesHost: dtr.dev.cray.com
   kubectlImageVersion: "0.2.0"
 
+# A list of gateways that keycloak is exposed
+  ingress:
+    gateways:
+    - "services-gateway"
+    - "customer-admin-gateway"
+    - "customer-user-gateway"
+
   keycloak:
     replicas: 3
     podAnnotations:


### PR DESCRIPTION
## Summary and Scope

Bi-CAN : Update the virtual service ingress cray-keycloak gateways to also include customer-admin-gateway and customer-user-gateway.

backward compatible since the service-gateway still remains as an ingress gatgeway.

## Issues and Related PRs

* Resolves [CASMPET-4953](BI-CAN: Update keycloak to use the new API Gateways)
* Change will also be needed in NA
* Future work required - Release cray-keycloak for csm-1.2
* Documentation changes required NA
* Merge with/before/after NA

## Testing

vshasta

### Tested on:
 before
 ```
$ kubectl get vs -A | grep keycloak
services            keycloak                           ["services-gateway"]            ["*"]                             6h2m
 ```
 after
 ```
$ kubectl get vs -A | grep keycloak
services            keycloak                           ["services-gateway","customer-admin-gateway","customer-user-gateway"]   ["*"]                             6h9m
 ```

### Test description:

Verified that the expected change to cray-keycloak gateways was visible after upgrading.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? NA
- Were continuous integration tests run? If not, why? NA
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? NA

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_ NA


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

