### PR TITLE
CASMPET-5163 master : Release keycloak-installer for CSM 1.2

### DIFF
--- a/kubernetes/cray-keycloak/Chart.yaml
+++ b/kubernetes/cray-keycloak/Chart.yaml
@@ -3,4 +3,4 @@ description: Deploys Keycloak for Shasta
 keywords:
 - keycloak
 name: cray-keycloak
-version: 2.0.0
+version: 2.1.0


### PR DESCRIPTION
Prep for release of keycloak-installer

* Includes CASMPET-4953 : BI-CAN: Update keycloak to use the new API Gateways