### PR TITLE
CASMPET-5155: keycloak-setup creates oauth2-proxy clients for bi-can

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,6 @@ services by requiring valid redirect URIs to be explicitly defined. Also,
 the keycloak-gatekeeper-client secret is created to enable keycloak-gatekeeper
 to connect to Keycloak.
 
-A Client called `oauth2-proxy` is created in Keycloak. This client is used by
-the OAuth2-Proxy ingress to facilitate authentication for web UIs,
-before forwarding traffic to the Istio ingress gateway, which uses OPA and
-enforces authorization. This client is configured to support specific
-services by requiring valid redirect URIs to be explicitly defined. Also,
-the oauth2-proxy-client secret is created that contains the client secret so
-that the OAuth2-Proxy can get the secret.
-
 A Client called `shasta` is created in Keycloak. This client is public and is
 meant to be used when accessing the Cray services. This client has protocol
 mappers that make the uid and gid attributes for the user available to the
@@ -98,6 +90,26 @@ log:
 
 ```
 unable to verify the id token	{"error": "oidc: JWT claims invalid: invalid claims, cannot find 'client_id' in 'aud' claim, aud=[shasta account], client_id=gatekeeper"}
+```
+
+Other clients can be added by setting the `KEYCLOAK_CLIENTS` environment
+variable to a JSON-encoded object where each key is the client ID and the value
+is an object that describes the client to create:
+
+```
+"<client_id>": {
+  "type": "<public or confidential>", -- Defaults to confidential
+  "standardFlowEnabled": <boolean>,  -- Defaults to false
+  "implicitFlowEnabled": <boolean>, -- Defaults to false
+  "directAccessGrantsEnabled": <boolean>, -- Defaults to false
+  "serviceAccountsEnabled": <boolean>, -- Defaults to false
+  "authorizationServicesEnabled": <boolean>, -- Defaults to false
+  "proxiedHosts": ["<hostname>"], -- Optional, redirectUris is not set on the client if this is left off
+  "secret": { -- Optional, if not set then no secret is created.
+    "name": "<name of secret to create>",
+    "namespaces": ["<namespace>", ...] }
+  },
+}
 ```
 
 #### Environment variables
@@ -131,16 +143,6 @@ unable to verify the id token	{"error": "oidc: JWT claims invalid: invalid claim
 - KEYCLOAK_GATEKEEPER_PROXIED_HOSTS: JSON-encoded list of hostnames that the
   keycloak-gatekeeper ingress will proxy. Used to set the list of valid
   redirect URIs for the gatekeeper client.
-- KEYCLOAK_OAUTH2_PROXY_CLIENT_ID: Name of the OAuth2-Proxy client.
-  Defaults to `oauth2-proxy`.
-- KEYCLOAK_OAUTH2_PROXY_CLIENT_SECRET_NAME: Name of the secret that stores the
-  OAuth2-Proxy client info. Defaults to `oauth2-proxy-client`.
-- KEYCLOAK_OAUTH2_PROXY_CLIENT_SECRET_NAMESPACES: JSON-encoded list of
-  namespaces that the gatekeeper client secret will be created in. Defaults to
-  `['services']`.
-- KEYCLOAK_OAUTH2_PROXY_CLIENT_PROXIED_HOSTS: JSON-encoded list of hostnames
-  that the OAuth2-Proxy ingress will proxy. Used to set the list of valid
-  redirect URIs for the gatekeeper client.
 - KEYCLOAK_CUSTOMER_ACCESS_URL: The URL used to access Keycloak from the
   customer access network (CAN). Necessary to properly configure
   keycloak-gatekeeper/OAuth2-Proxy ingress to connect to Keycloak and redirect
@@ -151,6 +153,7 @@ unable to verify the id token	{"error": "oidc: JWT claims invalid: invalid claim
   WLM client info. Defaults to `wlm-client-auth`.
 - KEYCLOAK_WLM_CLIENT_SECRET_NAMESPACES: JSON-encoded list of namespaces
   that the WLM client secret will be created in. Defaults to `["default"]`.
+- KEYCLOAK_CLIENTS: JSON-encoded object of clients to create.
 
 ### keycloak_localize.py
 

--- a/kubernetes/cray-keycloak/templates/keycloak-setup.yaml
+++ b/kubernetes/cray-keycloak/templates/keycloak-setup.yaml
@@ -105,18 +105,6 @@ spec:
           value: |
             {{ .Values.setup.keycloak.gatekeeper.client.secret.namespaces | toJson }}
 
-        # OAuth2-Proxy client
-        - name: KEYCLOAK_OAUTH2_PROXY_CLIENT_ID
-          value: "{{ .Values.setup.keycloak.oauth2Proxy.client.id }}"
-        - name: KEYCLOAK_OAUTH2_PROXY_CLIENT_SECRET_NAME
-          value: "{{ .Values.setup.keycloak.oauth2Proxy.client.secret.name }}"
-        - name: KEYCLOAK_OAUTH2_PROXY_CLIENT_SECRET_NAMESPACES
-          value: |
-            {{ .Values.setup.keycloak.oauth2Proxy.client.secret.namespaces | toJson }}
-        - name: KEYCLOAK_OAUTH2_PROXY_CLIENT_PROXIED_HOSTS
-          value: |
-            {{ .Values.setup.keycloak.oauth2Proxy.proxiedHosts | toJson }}
-
         # WLM client
         - name: KEYCLOAK_WLM_CLIENT_ID
           value: "{{ .Values.setup.keycloak.wlmClient.id }}"
@@ -125,6 +113,12 @@ spec:
         - name: KEYCLOAK_WLM_CLIENT_SECRET_NAMESPACES
           value: |
             {{ .Values.setup.keycloak.wlmClient.secret.namespaces | toJson }}
+
+        # Other clients
+        - name: KEYCLOAK_CLIENTS
+          value: |
+            {{ .Values.setup.keycloak.clients | toJson }}
+
         volumeMounts:
         - name: keycloak-master-admin-auth-vol
           mountPath: /mnt/keycloak-master-admin-auth-vol

--- a/kubernetes/cray-keycloak/values.yaml
+++ b/kubernetes/cray-keycloak/values.yaml
@@ -76,28 +76,37 @@ setup:
         - vcs_hostname.local
         - sma-grafana.local
         - sma-kibana.local
-    oauth2Proxy:
-      client:
-        id: oauth2-proxy
+    clients:
+      oauth2-proxy-customer-management:
+        type: confidential
+        standardFlowEnabled: true
+        serviceAccountsEnabled: true
+        proxiedHosts:
+        - override-me.cmn.local
         secret:
-          name: oauth2-proxy-client
+          name: oauth2-proxy-customer-management-client
           namespaces:
-            - services
-      proxiedHosts:
-        - shs_prometheus.local
-        - shs_alertmanager.local
-        - shs_grafana.local
-        - istio_prometheus.local
-        - istio_grafana.local
-        - istio_kiali.local
-        - istio_jaeger.local
-        - kube_monitoring_prometheus.local
-        - kube_monitoring_alertmanager.local
-        - kube_monitoring_grafana.local
-        - ceph_monitoring_prometheus.local
-        - vcs_hostname.local
-        - sma-grafana.local
-        - sma-kibana.local
+          - services
+      oauth2-proxy-customer-access:
+        type: confidential
+        standardFlowEnabled: true
+        serviceAccountsEnabled: true
+        proxiedHosts:
+        - override-me.can.local
+        secret:
+          name: oauth2-proxy-customer-access-client
+          namespaces:
+          - services
+      oauth2-proxy-customer-high-speed:
+        type: confidential
+        standardFlowEnabled: true
+        serviceAccountsEnabled: true
+        proxiedHosts:
+        - override-me.chn.local
+        secret:
+          name: oauth2-proxy-customer-high-speed-client
+          namespaces:
+          - services
     customerAccessUrl: "https://auth.local/keycloak"
     masterAdminSecretName: keycloak-master-admin-auth
 


### PR DESCRIPTION
### Summary and Scope

The bifurcated CAN feature requires changes to the way that the
keycloak-setup tool is configuring the client for the oauth2-proxy.
There will be a separate oauth2-proxy instance for each of the
networks and they will serve different hosts, so each one requires a
different client be created with the right hosts.

Rather than use the previous method of having env vars for each
setting, there's a new env var that contains a JSON string with the
settings for the different clients. This is easier to code up than the
separate env vars.

The cray-keycloak chart is enhanced to pass in this new env var and
also configures the JSON string.

The oauth2-proxy client is no longer created since it's no longer used.

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? New Feature

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? N/A

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N/A

### Issues and Related PRs

* Resolves CASMPET-5155

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested?      N   If not, Why? keycloak-setup doesn't handle cleaning up.
Was a Downgrade tested?     N.  If not, Why? ^
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed this to my virtual shasta. Checked the keycloak-setup logs, logged into keycloak to see the new clients. Verified that I could log in to kiali through oauth2-proxy.

### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

Requires: None
