### PR TITLE
CASMPET-3585 Correct a mistake in the nexus client secret env variable name

### DIFF
--- a/kubernetes/cray-keycloak/Chart.yaml
+++ b/kubernetes/cray-keycloak/Chart.yaml
@@ -3,4 +3,4 @@ description: Deploys Keycloak for Shasta
 keywords:
 - keycloak
 name: cray-keycloak
-version: 3.0.0
+version: 3.0.1

--- a/kubernetes/cray-keycloak/templates/keycloak-setup.yaml
+++ b/kubernetes/cray-keycloak/templates/keycloak-setup.yaml
@@ -91,7 +91,7 @@ spec:
         # by the Nexus Keycloak plugin during authentication.
         - name: KEYCLOAK_SYSTEM_NEXUS_CLIENT_ID
           value: "{{ .Values.setup.keycloak.systemNexusClient.id }}"
-        - name: KEYCLOAK_SYSTEM_PXE_CLIENT_SECRET_NAME
+        - name: KEYCLOAK_SYSTEM_NEXUS_CLIENT_SECRET_NAME
           value: "{{ .Values.setup.keycloak.systemNexusClient.secret.name }}"
         - name: KEYCLOAK_SYSTEM_NEXUS_CLIENT_SECRET_NAMESPACES
           value: |


### PR DESCRIPTION

## Summary and Scope

Fixes a mistake in the chart template nexus client secret env variable name:
      KEYCLOAK_SYSTEM_PXE_CLIENT_SECRET_NAME ->
      KEYCLOAK_SYSTEM_NEXUS_CLIENT_SECRET_NAME

## Issues and Related PRs

* Resolves CASMPET-3585

## Testing

### Tested on:

  * Mug

### Test description:

I verified the new Helm chart installed correctly after the change.

## Risks and Mitigations

None

