### PR TITLE
CASMPET-5033: Update image refs in Helm charts

### DIFF
--- a/.github/workflows/charts-lint-test-scan-cron.yml
+++ b/.github/workflows/charts-lint-test-scan-cron.yml
@@ -1,0 +1,17 @@
+name: Cron Lint, test, and scan Helm charts
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+jobs:
+  lint-test-scan:
+    uses: Cray-HPE/.github/.github/workflows/charts-lint-test-scan.yml@main
+    with:
+      ct-config: |
+        chart-dirs:
+          - kubernetes
+        validate-maintainers: false
+      scan-chart-snyk-args: "--severity-threshold=high --policy-path=kubernetes/.snyk"
+      scan-image-snyk-args: "--severity-threshold=high"
+    secrets:
+      snyk-token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/charts-lint-test-scan.yml
+++ b/.github/workflows/charts-lint-test-scan.yml
@@ -1,0 +1,21 @@
+name: Lint, test, and scan Helm charts
+on:
+  pull_request:
+    branches:
+      - master
+      - release/**
+  workflow_dispatch:
+jobs:
+  lint-test-scan:
+    uses: Cray-HPE/.github/.github/workflows/charts-lint-test-scan.yml@main
+    with:
+      scan-image-snyk-args: "--severity-threshold=high"
+      lint-charts: ${{ github.event_name == 'pull_request' }}
+      ct-config: |
+        chart-dirs:
+          - kubernetes
+        validate-maintainers: false
+      scan-chart-snyk-args: "--severity-threshold=high --policy-path=kubernetes/.snyk"
+      scan-images: false
+    secrets:
+      snyk-token: ${{ secrets.SNYK_TOKEN }}

--- a/kubernetes/.snyk
+++ b/kubernetes/.snyk
@@ -1,0 +1,11 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+ SNYK-CC-K8S-47:
+    - '*':
+        reason: The setup and configuration process requires these permissions.
+        expires: 2041-12-01T00:00:00.000Z
+        created: 2021-11-T00:32:42.642Z
+
+patch: {}

--- a/kubernetes/cray-keycloak-users-localize/Chart.yaml
+++ b/kubernetes/cray-keycloak-users-localize/Chart.yaml
@@ -1,6 +1,14 @@
-apiVersion: v1
+apiVersion: v2
+name: cray-keycloak-users-localize
+version: 1.10.0
 description: Customizes Keycloak deployment
 keywords:
 - keycloak
-name: cray-keycloak-users-localize
-version: 1.9.2
+- keycloak-users-localize
+home: https://github.com/Cray-HPE/keycloak-installer
+sources:
+- https://github.com/Cray-HPE/keycloak-installer
+maintainers:
+- name: brantk-hpe
+annotations:
+  artifacthub.io/license: MIT

--- a/kubernetes/cray-keycloak-users-localize/values.yaml
+++ b/kubernetes/cray-keycloak-users-localize/values.yaml
@@ -1,4 +1,3 @@
-
 # MIT License
 # (C) Copyright [2020-2021] Hewlett Packard Enterprise Development LP
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -18,8 +17,8 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 image:
-  repository: dtr.dev.cray.com/cray/cray-keycloak-setup
-  # tag: latest
+  repository: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup
+  # tag defaults to chart appVersion
   pullPolicy: Always
 
 # Determines how many times the Job will retry running the localize pod.

--- a/kubernetes/cray-keycloak/.gitignore
+++ b/kubernetes/cray-keycloak/.gitignore
@@ -1,1 +1,2 @@
 charts/
+requirements.lock

--- a/kubernetes/cray-keycloak/Chart.yaml
+++ b/kubernetes/cray-keycloak/Chart.yaml
@@ -1,6 +1,18 @@
-apiVersion: v1
+apiVersion: v2
+name: cray-keycloak
+version: 3.2.0
 description: Deploys Keycloak for Shasta
 keywords:
 - keycloak
-name: cray-keycloak
-version: 3.1.0
+- keycloak-setup
+home: https://github.com/Cray-HPE/keycloak-installer
+sources:
+- https://github.com/Cray-HPE/keycloak-installer
+dependencies:
+- name: keycloak
+  version: 7.2.0
+  repository: https://codecentric.github.io/helm-charts
+maintainers:
+- name: brantk-hpe
+annotations:
+  artifacthub.io/license: MIT

--- a/kubernetes/cray-keycloak/requirements.lock
+++ b/kubernetes/cray-keycloak/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: keycloak
-  repository: https://codecentric.github.io/helm-charts
-  version: 7.2.0
-digest: sha256:4e91c1f9c03ef051090595d544c1a5242812b15371eed0db49f98822ea9a16ab
-generated: "2020-03-11T15:40:39.7085077Z"

--- a/kubernetes/cray-keycloak/requirements.yaml
+++ b/kubernetes/cray-keycloak/requirements.yaml
@@ -1,5 +1,0 @@
----
-dependencies:
-  - name: keycloak
-    version: "7.2.0"
-    repository: "@codecentric"

--- a/kubernetes/cray-keycloak/templates/postgresql.yaml
+++ b/kubernetes/cray-keycloak/templates/postgresql.yaml
@@ -123,7 +123,8 @@ spec:
       restartPolicy: Never
       containers:
         - name: "postgres-watcher-service-db"
-          image: "{{ .Values.imagesHost }}/cache/postgres:13.2"
+          image: {{ .Values.sqlCluster.image.repository }}:{{ .Values.sqlCluster.image.tag }}
+          imagePullPolicy: {{ .Values.sqlCluster.image.pullPolicy }}
           securityContext:
             runAsUser: 65534
             runAsGroup: 65534

--- a/kubernetes/cray-keycloak/values.yaml
+++ b/kubernetes/cray-keycloak/values.yaml
@@ -1,13 +1,34 @@
+# MIT License
+# (C) Copyright [2020-2021] Hewlett Packard Enterprise Development LP
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
 
-imagesHost: dtr.dev.cray.com
+sqlCluster:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/postgres
+    tag: 13.2-alpine
+    pullPolicy: IfNotPresent
 
 # A list of sealedSecrets passed in to be deployed.
 sealedSecrets: []
 
 setup:
   image:
-    repository: dtr.dev.cray.com/cray/cray-keycloak-setup
-    # tag: latest
+    repository: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup
+    # tag defaults to chart appVersion or `latest`
     pullPolicy: Always
   keycloak:
     service: keycloak
@@ -112,8 +133,11 @@ setup:
 
 keycloak:
   # Custom value for init container image source
-  imagesHost: dtr.dev.cray.com
-  kubectlImageVersion: "0.2.0"
+  kubectl:
+    image:
+      repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+      tag: 1.19.15
+      pullPolicy: IfNotPresent
 
 # A list of gateways that keycloak is exposed
   ingress:
@@ -121,6 +145,10 @@ keycloak:
     - "services-gateway"
     - "customer-admin-gateway"
     - "customer-user-gateway"
+
+  test:
+    image:
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/unguiculus/docker-python3-phantomjs-selenium
 
   keycloak:
     replicas: 3
@@ -130,6 +158,7 @@ keycloak:
       traffic.sidecar.istio.io/excludeInboundPorts: '7600'
       traffic.sidecar.istio.io/excludeOutboundPorts: '7600'
     image:
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/jboss/keycloak
       tag: 9.0.0
     # NOTE: When upgrading this should be able to be removed. -XX:+UseContainerSupport is the default in chart version 7.3.0
     extraEnv: |
@@ -176,7 +205,8 @@ keycloak:
     # This is copied from cray-services
     extraInitContainers: |
       - name: keycloak-wait-for-postgres
-        image: {{ .Values.imagesHost }}/loftsman/docker-kubectl:{{ .Values.kubectlImageVersion }}
+        image: {{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}
+        imagePullPolicy: {{ .Values.kubectl.image.pullPolicy }}
         command:
         - /bin/sh
         - -c
@@ -258,9 +288,9 @@ keycloak:
 postgresDbBackup:
   enabled: true
   image:
-    repository: "dtr.dev.cray.com/cray/cray-postgres-db-backup"
+    repository: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup
+    tag: 0.2.0
     pullPolicy: IfNotPresent
-    tag: "0.1.0"
 
   storageBucket: postgres-backup
   storageSecret: postgres-backup-s3-credentials


### PR DESCRIPTION
### Summary and Scope

Replaced image references to deprecated registries with the
current registry. References to dtr were replaced with algol60.

I updated the postgres-related templates with what's in
base-charts to bring those image refs into alignment.

The jboss/keycloak and unguiculus/docker-python3-phantomjs-selenium:v1
images are now using the ones built by container-images.

The chart.yaml files were updated to v2.

Workflows are configured.

See https://connect.us.cray.com/jira/browse/CASM-2670

IS THIS A NEW FEATURE OR CRITICAL BUG FIX? bug fix

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? Y

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: Copyright 2014-2021 Hewlett Packard Enterprise Development LP    ? N

### Issues and Related PRs

* Resolves CASMPET-5033

### Testing

Tested on:

* Virtual Shasta

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) N
Was a fresh Install tested? Y
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

WHAT WAS THE EXTENT OF TESTING PERFORMED? MANUAL VERSUS AUTOMATED TESTS (UNIT/SMOKE/OTHER) manual
HOW WERE CHANGES VERIFIED TO BE SUCCESSFUL?

Deployed the charts and made sure the cray-keycloak statefulset, keycloak-setup job, keycloak-users-localize job, keycloak-wait-for-postgres job, and cray-keycloak-postgresql-db-backup cronjob were all using the expected images.

Logged into the Keycloak admin GUI and got a token to make sure Keycloak is still working.

Changed the Keycloak Postgresql backup schedule so that it ran and saw that it ran, checked the log.


### Risks and Mitigations

IF APPLICABLE, HAS A SECURITY AUDIT (via SNYK OR OTHERWISE) BEEN RUN? N
ARE THERE KNOWN ISSUES WITH THESE CHANGES? N
ANY OTHER SPECIAL CONSIDERATIONS? N

Requires: None
