### PR TITLE
CASMPET-5812: Add keycloak service to the hmn-gateway

### DIFF
--- a/kubernetes/cray-keycloak/Chart.yaml
+++ b/kubernetes/cray-keycloak/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-keycloak
-version: 3.5.1
+version: 3.6.0
 description: Deploys Keycloak for Shasta
 keywords:
 - keycloak

--- a/kubernetes/cray-keycloak/values.yaml
+++ b/kubernetes/cray-keycloak/values.yaml
@@ -150,6 +150,7 @@ keycloak:
     - "services-gateway"
     - "customer-admin-gateway"
     - "customer-user-gateway"
+    - "hmn-gateway"
 
   test:
     image:


### PR DESCRIPTION
## Summary and Scope

Add keycloak service to hmn-gateway to enable authorization for new fabric_manager service.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5812](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5812)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

Verified that the cray-keycloak service is now exposed to hmn-gateway in addition to other gateways after upgrading.

$ kubectl get vs -A | grep keycloak
services            keycloak                           ["services-gateway","customer-admin-gateway","customer-user-gateway","hmn-gateway"]   ["*"]

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

