### PR TITLE
CASMPET-5936: restore postgres from backup encountered errors

### DIFF
--- a/kubernetes/cray-keycloak/Chart.yaml
+++ b/kubernetes/cray-keycloak/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-keycloak
-version: 3.3.1
+version: 3.3.2
 description: Deploys Keycloak for Shasta
 keywords:
 - keycloak

--- a/kubernetes/cray-keycloak/values.yaml
+++ b/kubernetes/cray-keycloak/values.yaml
@@ -294,7 +294,7 @@ postgresDbBackup:
   enabled: true
   image:
     repository: artifactory.algol60.net/csm-docker/stable/cray-postgres-db-backup
-    tag: 0.2.0
+    tag: 0.2.3
     pullPolicy: IfNotPresent
 
   storageBucket: postgres-backup


### PR DESCRIPTION
## Summary and Scope

Change the default tag of cray-postgres-db-backup to 0.2.3 to fix postgres sql version incompatibility causing restore to fail. Bumped the chart patch version.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially Resolves [CASMPET-5936](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5936)
* Change will also be needed in `<insert branch name here>`
* Future work required by [CASMPET-5936](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5936)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_
Verified that cray-keycloak chart can restore the backed up image successfully with the new image.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

