### PR TITLE
CASMPET-6305: Update ldap cert config

### DIFF
--- a/kubernetes/cray-keycloak/Chart.yaml
+++ b/kubernetes/cray-keycloak/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-keycloak
-version: 4.0.0
+version: 4.0.1
 description: Deploys Keycloak for Shasta
 keywords:
 - keycloak

--- a/kubernetes/cray-keycloak/values.yaml
+++ b/kubernetes/cray-keycloak/values.yaml
@@ -284,15 +284,6 @@ keycloak:
     limits:
       memory: "5000Mi"
       cpu: "4000m"
-  cli:
-    # Configures Keycloak to read a CA cert from /certs/cert.jks, would contain the custom LDAP server certificate.
-    custom: |
-      /subsystem=keycloak-server/spi=truststore:add()
-      /subsystem=keycloak-server/spi=truststore/provider=file:add(enabled=true)
-      /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=properties.file,value=/certs/certs.jks)
-      /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=properties.password,value=password)
-      /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=properties.hostname-verification-policy,value=WILDCARD)
-      /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=properties.disabled,value=false)
   # Contains the CA cert, it's created outside of this chart and may be updated by localization.
   extraVolumes: |
     - name: certs-volume
@@ -333,6 +324,18 @@ keycloak:
       /subsystem=undertow/server=default-server/host=default-host:write-attribute(name=default-web-module,value=keycloak-server.war)
       {{- end }}
       {{- end }}
+      run-batch
+      stop-embedded-server
+    # Configures Keycloak to read a CA cert from /certs/cert.jks, would contain the custom LDAP server certificate.
+    configureCerts.cli: |
+      embed-server --server-config=standalone-ha.xml --std-out=echo
+      batch
+      /subsystem=keycloak-server/spi=truststore:add()
+      /subsystem=keycloak-server/spi=truststore/provider=file:add(enabled=true)
+      /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=properties.file,value=/certs/certs.jks)
+      /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=properties.password,value=password)
+      /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=properties.hostname-verification-policy,value=WILDCARD)
+      /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=properties.disabled,value=false)
       run-batch
       stop-embedded-server
 


### PR DESCRIPTION
## Summary and Scope

The keylcoak upgrade missed a small change in configuration that set the ldap cert. This would only affect systems with self signed certificates which we no longer have ineternally.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6305](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6305)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * surtur

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? y
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? y

## Risks and Mitigations

No new risks


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

