### PR TITLE
CASMPET-6431: Move startup scripts to init container

### DIFF
--- a/kubernetes/cray-keycloak/Chart.yaml
+++ b/kubernetes/cray-keycloak/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-keycloak
-version: 5.0.0
+version: 5.0.1
 description: Deploys Keycloak for Shasta
 keywords:
 - keycloak

--- a/kubernetes/cray-keycloak/values.yaml
+++ b/kubernetes/cray-keycloak/values.yaml
@@ -190,6 +190,9 @@ keycloakx:
     - "--http-port=8080"
     - "--hostname-strict=false"
     - "--hostname-strict-https=false"
+    - "--spi-truststore-file-file=/certs/certs.jks"
+    - "--spi-truststore-file-password=password"
+    - "--spi-truststore-file-hostname-verification-policy=WILDCARD"
   extraEnv: |
     - name: JAVA_OPTS_APPEND
       value: >-
@@ -281,6 +284,28 @@ keycloakx:
         requests:
           cpu: 30m
           memory: 20Mi
+    - name: rsa-plugin
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15
+      imagePullPolicy: IfNotPresent
+      command:
+        - sh
+      args:
+        - -c
+        - |
+          echo "Copying Provider..."
+          cp /mnt/rsa-plugin/RSA-CLI-Provider.jar /providers/
+          cp /mnt/rsa-plugin/RSA-Plugin-Provider.jar /providers/
+          echo "Copying Theme..."
+          mkdir -p /themes/shasta-rsa/login/
+          cp /mnt/rsa-plugin/RSAAuthenticator.ftl /themes/shasta-rsa/login/
+          echo -e "parent=base\nimport=common/keycloak" > /themes/shasta-rsa/theme.properties
+      volumeMounts:
+        - name: providers
+          mountPath: /providers
+        - name: rsa-plugin-plugin-volume
+          mountPath: /mnt/rsa-plugin
+        - name: themes
+          mountPath: /themes
 
   http:
     relativePath: '/keycloak'
@@ -300,6 +325,10 @@ keycloakx:
     - name: rsa-plugin-plugin-volume
       configMap:
         name: cray-keycloak-rsa-plugin
+    - name: providers
+      emptyDir: {}
+    - name: themes
+      emptyDir: {}
   extraVolumeMounts: |
     - mountPath: /certs
       name: certs-volume
@@ -307,19 +336,8 @@ keycloakx:
     - name: rsa-plugin-plugin-volume
       mountPath: /mnt/rsa-plugin
       readOnly: true
-  startupScripts:
-    rsa_plugin_cli: "cp /mnt/rsa-plugin/RSA-CLI-Provider.jar /opt/jboss/keycloak/standalone/deployments/"
-    rsa_plugin_plugin: "cp /mnt/rsa-plugin/RSA-Plugin-Provider.jar /opt/jboss/keycloak/standalone/deployments/"
-    rsa_plugin_theme: "cp /mnt/rsa-plugin/RSAAuthenticator.ftl /opt/jboss/keycloak/themes/base/login/"
-    # Configures Keycloak to read a CA cert from /certs/cert.jks, would contain the custom LDAP server certificate.
-    configureCerts.cli: |
-      embed-server --server-config=standalone-ha.xml --std-out=echo
-      batch
-      /subsystem=keycloak-server/spi=truststore:add()
-      /subsystem=keycloak-server/spi=truststore/provider=file:add(enabled=true)
-      /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=properties.file,value=/certs/certs.jks)
-      /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=properties.password,value=password)
-      /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=properties.hostname-verification-policy,value=WILDCARD)
-      /subsystem=keycloak-server/spi=truststore/provider=file:write-attribute(name=properties.disabled,value=false)
-      run-batch
-      stop-embedded-server
+    - name: providers
+      mountPath: /opt/keycloak/providers
+    - name: themes
+      mountPath: /opt/keycloak/themes
+

--- a/kubernetes/cray-keycloak/values.yaml
+++ b/kubernetes/cray-keycloak/values.yaml
@@ -340,4 +340,3 @@ keycloakx:
       mountPath: /opt/keycloak/providers
     - name: themes
       mountPath: /opt/keycloak/themes
-


### PR DESCRIPTION
## Summary and Scope

This fixed a change in the keycloak upstream chart that took the startup scripts and mounted them but never ran them. They have now been moved to an init container as documented in the upstream notes. The change allowed for self signed certs for ldap as well as RSA implementation to work again.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6431](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6431)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Dorian

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?n

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

