### PR TITLE
CASMPET-6694: Bump PyYAML from 6.0 to 6.0.1 to prevent build issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.3]
+### Dependencies
+- Bump `PyYAML` from 6.0 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601
+
 ## [3.7.0]
 ### Changed
 - Updated base chart to version 16.1.0.

--- a/constraints.txt
+++ b/constraints.txt
@@ -28,7 +28,7 @@ pyparsing==3.0.7
 pytest==6.2.5
 pytest-cov==3.0.0
 python-dateutil==2.8.2
-PyYAML==6.0
+PyYAML==6.0.1
 requests==2.27.1
 requests-oauthlib==1.3.0
 responses==0.17.0


### PR DESCRIPTION
## Summary and Scope

With the release of Cython 3, any Alpine images trying to install PyYAML hit failures due to [this upstream issue](https://github.com/yaml/pyyaml/issues/601). See [CASMCMS-8713](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8713) for full details. The TL;DR summary is that moving to PyYAML 6.0.1 resolves the problem. There is no functional difference between PyYAML 6.0 and 6.0.1. The only difference is that 6.0.1 imposes a restriction on the Cython version used to build the module during installs. Specifically, it requires Cython < 3, which is the same behavior as PyYAML 6.0 had up until Cython 3 was released.

Even shorter summary: This PR allows builds in this repo to once again work, while making no functional changes to the things being built.

## Issues and Related PRs

* [PyYAML upstream issue](https://github.com/yaml/pyyaml/issues/601)
* [PR that created PyYAML 6.0.1 to fix the problem](https://github.com/yaml/pyyaml/pull/702)
* [CASMPET-6694](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6694) - Ticket I opened for this issue in the PET repos.
* [CASMCMS-8713](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8713) - The Jira ticket I'm using to fix the affected CSM repos

## Risks and Mitigations

Very low risk. And without this, the repo builds will fail.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
