### PR TITLE
CASMPET-6904 update cert-manager api version

### DIFF
--- a/kubernetes/cray-keycloak/Chart.yaml
+++ b/kubernetes/cray-keycloak/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-keycloak
-version: 5.0.5
+version: 5.1.0
 description: Deploys Keycloak for Shasta
 keywords:
 - keycloak

--- a/kubernetes/cray-keycloak/Chart.yaml
+++ b/kubernetes/cray-keycloak/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-keycloak
-version: 5.0.4
+version: 5.0.5
 description: Deploys Keycloak for Shasta
 keywords:
 - keycloak

--- a/kubernetes/cray-keycloak/templates/postgresql.yaml
+++ b/kubernetes/cray-keycloak/templates/postgresql.yaml
@@ -25,7 +25,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 # This file is copied from the cray-service chart
 
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: "keycloak-postgres-tls"
@@ -33,13 +33,15 @@ spec:
   secretName: "keycloak-postgres-tls"
   duration: 720h
   renewBefore: 24h
-  organization:
+  subject:
+    organizations:
     - Cray
   commonName: "keycloak-postgres.{{ .Release.Namespace }}.cluster.svc"
   isCA: false
-  keySize: 2048
-  keyAlgorithm: rsa
-  keyEncoding: pkcs1
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048 
   usages:
     - server auth
     - client auth


### PR DESCRIPTION
## Summary and Scope

Update cert-manager api version from v1alpha2 to v1. This is necessary for the cert-manager upgrade to v1.12.9 that is happening in CSM 1.6.

## Issues and Related PRs

* Relates to [CASMPET-6904](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6904)

## Testing

### Tested on:

  * Beau

### Test description:

Upgraded the cray-keycloak chart.

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

