### PR TITLE
CASMPET-7221 update docker-kubectl version to 1.24.17

### DIFF
--- a/kubernetes/cray-keycloak/Chart.yaml
+++ b/kubernetes/cray-keycloak/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-keycloak
-version: 5.1.1
+version: 5.1.2
 description: Deploys Keycloak for Shasta
 keywords:
 - keycloak

--- a/kubernetes/cray-keycloak/values.yaml
+++ b/kubernetes/cray-keycloak/values.yaml
@@ -25,7 +25,7 @@
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.19.15
+    tag: 1.24.17
 
 sqlCluster:
   image:
@@ -164,7 +164,7 @@ keycloakx:
   kubectl:
     image:
       repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-      tag: 1.19.15
+      tag: 1.24.17
       pullPolicy: IfNotPresent
 
   # A list of gateways that keycloak is exposed


### PR DESCRIPTION
## Summary and Scope

For k8s 1.24 in CSM 1.6, the docker-kubectl container image should be updated so that it is using version 1.24.17.

## Issues and Related PRs

* Relates to [CASMPET-7221](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7221)

## Testing

### Tested on:

  * Beau (vshasta2)

### Test description:

I upgraded the cray-keycloak chart. 

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

