### PR TITLE
CASMPET-7251 wait-for-postgres container should succeed if job status SuccessCriteriaMet

### DIFF
--- a/kubernetes/cray-keycloak/Chart.yaml
+++ b/kubernetes/cray-keycloak/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-keycloak
-version: 5.1.2
+version: 5.1.3
 description: Deploys Keycloak for Shasta
 keywords:
 - keycloak

--- a/kubernetes/cray-keycloak/values.yaml
+++ b/kubernetes/cray-keycloak/values.yaml
@@ -269,7 +269,7 @@ keycloakx:
           JOB_CONDITION="$(kubectl get jobs -n services -l app.kubernetes.io/name=keycloak-wait-for-postgres -o jsonpath='{.items[0].status.conditions[0].type}')"
           JOB_CONDITION_RC=$?
           if [ $JOB_CONDITION_RC -eq 0 ]; then
-            if [ "$JOB_CONDITION" == 'Complete' ]; then
+            if [ "$JOB_CONDITION" == 'Complete' -o "$JOB_CONDITION" == 'SuccessCriteriaMet' ]; then
               echo "Completed"
               break
             fi


### PR DESCRIPTION
## Summary and Scope

As of k8s 1.30 Job has a new JobConditionType of SuccessCriteriaMet.  Currently all checks for completed jobs are checking for a type of Complete.  These all need to be updated to also check for SuccessCriteriaMet.

## Issues and Related PRs

* Resolves [CASMPET-7251](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7251)

## Testing

### Tested on:

  * Beau (vShasta2)

### Test description:

I upgraded the cray-keycloak chart and observed the `wait-for-postgres` init container was working as expected. Output from the `wait-for-postgres` container is below

```text
ncn-m001:~ # kubectl logs -n services cray-keycloak-0 -c keycloak-wait-for-postgres -f
Waiting for the keycloak-wait-for-postgres job in the services namespace to complete, current condition is {"active":1,"ready":0,"startTime":"2024-12-13T21:30:16Z"}
Waiting for the keycloak-wait-for-postgres job in the services namespace to complete, current condition is {"active":1,"ready":0,"startTime":"2024-12-13T21:30:16Z"}
Waiting for the keycloak-wait-for-postgres job in the services namespace to complete, current condition is {"active":1,"ready":0,"startTime":"2024-12-13T21:30:16Z"}
Waiting for the keycloak-wait-for-postgres job in the services namespace to complete, current condition is {"active":1,"ready":0,"startTime":"2024-12-13T21:30:16Z"}
Waiting for the keycloak-wait-for-postgres job in the services namespace to complete, current condition is {"active":1,"ready":0,"startTime":"2024-12-13T21:30:16Z"}
Waiting for the keycloak-wait-for-postgres job in the services namespace to complete, current condition is {"active":1,"ready":0,"startTime":"2024-12-13T21:30:16Z"}
Waiting for the keycloak-wait-for-postgres job in the services namespace to complete, current condition is {"active":1,"ready":0,"startTime":"2024-12-13T21:30:16Z"}
Waiting for the keycloak-wait-for-postgres job in the services namespace to complete, current condition is {"active":1,"ready":0,"startTime":"2024-12-13T21:30:16Z"}
Waiting for the keycloak-wait-for-postgres job in the services namespace to complete, current condition is {"active":1,"ready":0,"startTime":"2024-12-13T21:30:16Z"}
Waiting for the keycloak-wait-for-postgres job in the services namespace to complete, current condition is {"active":1,"ready":0,"startTime":"2024-12-13T21:30:16Z"}
Waiting for the keycloak-wait-for-postgres job in the services namespace to complete, current condition is {"active":1,"ready":0,"startTime":"2024-12-13T21:30:16Z"}
Waiting for the keycloak-wait-for-postgres job in the services namespace to complete, current condition is {"active":1,"ready":0,"startTime":"2024-12-13T21:30:16Z"}
Waiting for the keycloak-wait-for-postgres job in the services namespace to complete, current condition is {"active":1,"ready":0,"startTime":"2024-12-13T21:30:16Z"}
Waiting for the keycloak-wait-for-postgres job in the services namespace to complete, current condition is {"active":1,"ready":0,"startTime":"2024-12-13T21:30:16Z"}
Completed
```

## Risks and Mitigations

Low risk. This change is backwards compatible.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

