### PR TITLE
CASMPET-7533: Update postgres version for keycloak

### DIFF
--- a/kubernetes/cray-keycloak-users-localize/Chart.yaml
+++ b/kubernetes/cray-keycloak-users-localize/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-keycloak-users-localize
-version: 1.11.5
+version: 1.11.6
 description: Customizes Keycloak deployment
 keywords:
 - keycloak

--- a/kubernetes/cray-keycloak-users-localize/values.yaml
+++ b/kubernetes/cray-keycloak-users-localize/values.yaml
@@ -23,7 +23,7 @@
 #
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup
-  # tag defaults to chart appVersion which is set by jenkins during build based on .version file
+  tag: 3.9.0
   pullPolicy: Always
 
 # Determines how many times the Job will retry running the localize pod.

--- a/kubernetes/cray-keycloak/Chart.yaml
+++ b/kubernetes/cray-keycloak/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-keycloak
-version: 5.1.4
+version: 5.2.0
 description: Deploys Keycloak for Shasta
 keywords:
 - keycloak

--- a/kubernetes/cray-keycloak/templates/postgresql.yaml
+++ b/kubernetes/cray-keycloak/templates/postgresql.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -41,7 +41,7 @@ spec:
   privateKey:
     algorithm: RSA
     encoding: PKCS1
-    size: 2048 
+    size: 2048
   usages:
     - server auth
     - client auth
@@ -72,7 +72,7 @@ spec:
   enableLogicalBackup: true
   logicalBackupSchedule: "{{ .Values.sqlCluster.logicalBackup.schedule }}"
   postgresql:
-    version: "14" # Needs to match version of spilo as defined in the cray-postgres-operator chart
+    version: "15" # Needs to match version of spilo as defined in the cray-postgres-operator chart
   tls:
     secretName: "keycloak-postgres-tls"
 

--- a/kubernetes/cray-keycloak/values.yaml
+++ b/kubernetes/cray-keycloak/values.yaml
@@ -25,12 +25,12 @@
 kubectl:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-    tag: 1.24.17
+    tag: 1.32.2
 
 sqlCluster:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/docker.io/library/postgres
-    tag: 13.2-alpine
+    tag: 15-alpine
     pullPolicy: IfNotPresent
 
   # The logical backup configurations are set in the operatorconfiguration and cannot be overridden per cluster;
@@ -45,7 +45,7 @@ sealedSecrets: []
 setup:
   image:
     repository: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup
-    # tag defaults to chart appVersion which is set by jenkins during build based on .version file
+    tag: 3.9.0
     pullPolicy: Always
   keycloak:
     service: keycloak
@@ -164,7 +164,7 @@ keycloakx:
   kubectl:
     image:
       repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
-      tag: 1.24.17
+      tag: 1.32.2
       pullPolicy: IfNotPresent
 
   # A list of gateways that keycloak is exposed


### PR DESCRIPTION
## Summary and Scope

Updating Postgres Version used by cray-keycloak

## Issues and Related PRs

* Resolves [CASMPET-7533](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7533)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?y
- Were continuous integration tests run? If not, why?y
- Was upgrade tested? If not, why?y
- Was downgrade tested? If not, why?y
- Were new tests (or test issues/Jiras) created for this change?y

## Risks and Mitigations

Small risk changing postgres versions if there is a bug in the newer version, but should limit risk due to a new version

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x]  CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

